### PR TITLE
skimage not required

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-scikit-image==0.12.3
 pandas>=0.20.3
 numpy>=1.13.3


### PR DESCRIPTION
I could not find anywhere in the code base that imported from skimage. Why is this a required installation?