### PR TITLE
Bug: OptArg values

### DIFF
--- a/test_tube/argparse_hopt.py
+++ b/test_tube/argparse_hopt.py
@@ -369,11 +369,12 @@ class OptArg(object):
 
             if log_base is None:
                 # random search on uniform scale
-                opt_values = np.random.uniform(low, high, nb_samples)
+                self.opt_values = np.random.uniform(low, high, nb_samples)
             else:
                 # random search on log scale with specified base
                 assert high >= low > 0, "`opt_values` must be positive to do log-scale search."
 
                 log_low, log_high = math.log(low, log_base), math.log(high, log_base)
 
-                self.opt_values = log_base ** np.random.uniform(log_low, log_high)
+                self.opt_values = log_base ** np.random.uniform(log_low, log_high, nb_samples)
+


### PR DESCRIPTION
-fix self.opt_values calculation:
    - log_base undefined: missing assignment
    - log_base defined: only one number was calculated (instead of list of nb samples, which caused errors in iteration of opt_values in __flatten_params)