### PR TITLE
Add dry run option.

### DIFF
--- a/test_tube/argparse_hopt.py
+++ b/test_tube/argparse_hopt.py
@@ -65,6 +65,7 @@ class HyperOptArgumentParser(ArgumentParser):
     SLURM_CMD_PATH = 'test_tube_slurm_cmd_path'
     SLURM_EXP_CMD = 'hpc_exp_number'
     SLURM_LOAD_CMD = 'test_tube_do_checkpoint_load'
+    DRY_RUN_CMD = 'test_tube_dry_run'
     CMD_MAP = {
         TRIGGER_CMD: bool,
         SLURM_CMD_PATH: str,
@@ -88,6 +89,12 @@ class HyperOptArgumentParser(ArgumentParser):
         self.opt_args = {}
         self.json_config_arg_name = None
         self.pool = None
+
+        self.add_argument(
+            self.DRY_RUN_CMD,
+            default=False,
+            action='store_true',
+            help='Will only print out hyparameters to stdout.')
 
     def add_argument(self, *args, **kwargs):
         super(HyperOptArgumentParser, self).add_argument(*args, **kwargs)

--- a/test_tube/hpc.py
+++ b/test_tube/hpc.py
@@ -167,6 +167,7 @@ class SlurmCluster(AbstractCluster):
         # whenever this script is called by slurm, it's an actual experiment, so start it
         if self.is_from_slurm_object:
             self.__run_experiment(train_function)
+            return
 
         # generate hopt trials
         trials = self.hyperparam_optimizer.generate_trials(nb_trials)


### PR DESCRIPTION
I found this super useful to debug where I was going wrong. I realized that `tunable` is False by default, which to me is intuitive when I'm using `opt_list` etc....

Also I don't know where to find the appropriate place in the doc to put it.

Basically it works as follows:

```
python3 tt_hyperparameter_launcher.py --test_tube_dry_run
```
