### PR TITLE
Update examples to be cleaner and more descriptive.

### DIFF
--- a/examples/hpc_cpu_example.py
+++ b/examples/hpc_cpu_example.py
@@ -1,77 +1,85 @@
+"""Example launcher for a hyperparameter search on SLURM."""
 from test_tube import Experiment, HyperOptArgumentParser, SlurmCluster
 
-"""
-Example script to show how to run a hyperparameter search on a cluster managed by SLURM
 
-Every distinct set of hyperparams runs on the configured hardware described in the SlurmCluster set up
-"""
+def train(hparams, *args):
+    """Train your awesome model.
 
-
-# main training function (very simple)
-def train(hparams):
-
-    # this won't crash ever. If no exp number is there, it'll be None
-    exp_version_from_slurm_script = hparams.hpc_exp_number
-
-    # init exp and track all the parameters from the HyperOptArgumentParser
-    # the experiment version is optional, but using the one from slurm means the exp will not collide with other
-    # versions if slurm runs multiple at once.
+    :param hparams: The arguments to run the model with.
+    """
+    # Initialize experiments and track all the hyperparameters
     exp = Experiment(
         name=hparams.test_tube_exp_name,
+        # Location to save the metrics.
         save_dir=hparams.log_path,
-        version=exp_version_from_slurm_script,
+        # The experiment version is optional, but using the one 
+        # from SLURM means the exp will not collide with other
+        # versions if SLURM runs multiple at once.
+        version=hparams.hpc_exp_number,
         autosave=False,
     )
     exp.argparse(hparams)
 
-    # pretend to train
+    # Pretend to train.
     x = hparams.x_val
     for train_step in range(0, 100):
         y = hparams.y_val
         out = x * y
-        exp.log({'fake_err': out.item()})
+        exp.log({'fake_err': out.item()})  # Log metrics.
 
-    # save exp when we're done
+    # Save exp when done.
     exp.save()
 
 
-# set up our argparser and make the y_val tunable
-parser = HyperOptArgumentParser(strategy='random_search')
-parser.add_argument('--test_tube_exp_name', default='my_test')
-parser.add_argument('--log_path', default='/some/path/to/log')
-parser.opt_list('--y_val', default=12, options=[1, 2, 3, 4, 5, 6], tunable=True)
-parser.opt_list('--x_val', default=12, options=[20, 12, 30, 45], tunable=True)
-hyperparams = parser.parse_args()
+if __name__ == '__main__':
+    # Set up our argparser and make the y_val tunable.
+    parser = HyperOptArgumentParser(strategy='random_search')
+    parser.add_argument('--test_tube_exp_name', default='my_test')
+    parser.add_argument('--log_path', default='/some/path/to/log')
+    parser.opt_list('--y_val',
+        default=12, options=[1, 2, 3, 4, 5, 6], tunable=True)
+    parser.opt_list('--x_val',
+        default=12, options=[20, 12, 30, 45], tunable=True)
+    hyperparams = parser.parse_args()
 
-# enable cluster training
-cluster = SlurmCluster(
-    hyperparam_optimizer=hyperparams,
-    log_path=hyperparams.log_path,
-    python_cmd='python3',
-    test_tube_exp_name=hyperparams.test_tube_exp_name
-)
+    # Enable cluster training.
+    cluster = SlurmCluster(
+        hyperparam_optimizer=hyperparams,
+        log_path=hyperparams.log_path,
+        python_cmd='python3',
+        test_tube_exp_name=hyperparams.test_tube_exp_name
+    )
 
-# email results if your hpc supports it
-cluster.notify_job_status(email='some@email.com', on_done=True, on_fail=True)
+    # Email results if your hpc supports it.
+    cluster.notify_job_status(
+        email='some@email.com', on_done=True, on_fail=True)
 
-# any modules for code to run in env
-cluster.load_modules([
-    'python-3',
-    'anaconda3'
-])
-# add commands to the non slurm portion
-cluster.add_command('source activate myCondaEnv')
+    # SLURM Module to load.
+    cluster.load_modules([
+        'python-3',
+        'anaconda3'
+    ])
 
-# can also add custom slurm commands which show up as:
-# #comment
-# #SBATCH --cmd=value
-# ############
-# cluster.add_slurm_cmd(cmd='cpus-per-task', value='1', comment='nb cpus per task')
+    # Add commands to the non-SLURM portion.
+    cluster.add_command('source activate myCondaEnv')
 
-# set job compute details (this will apply PER set of hyperparameters)
-cluster.per_experiment_nb_cpus = 20
-cluster.per_experiment_nb_nodes = 10
+    # Add custom SLURM commands which show up as:
+    # #comment
+    # #SBATCH --cmd=value
+    # ############
+    # cluster.add_slurm_cmd(
+    #    cmd='cpus-per-task', value='1', comment='CPUS per task.')
 
-# each job (24 in total here) will use 200 cpus for each set of hyperparams
-# if job_display_name is set, it's what will display in the slurm queue
-cluster.optimize_parallel_cluster_cpu(train, nb_trials=24, job_name='first_tt_job', job_display_name='short_name')
+    # Set job compute details (this will apply PER set of hyperparameters.)
+    cluster.per_experiment_nb_cpus = 20
+    cluster.per_experiment_nb_nodes = 10
+
+    # Each hyperparameter combination will use 200 cpus.
+    cluster.optimize_parallel_cluster_cpu(
+        # Function to execute:
+        train,
+        # Number of hyperparameter combinations to search:
+        nb_trials=24,
+        job_name='first_tt_job',
+        # This is what will display in the slurm queue:
+        job_display_name='short_name')

--- a/examples/pytorch_hpc_example.py
+++ b/examples/pytorch_hpc_example.py
@@ -1,65 +1,84 @@
+"""Example launcher for a hyperparameter search on SLURM.
+
+This example shows how to use gpus on SLURM with PyTorch.
+"""
 import torch
 from test_tube import Experiment, HyperOptArgumentParser, SlurmCluster
 
+def train(hparams, *args):
+    """Train your awesome model.
 
-"""
-Example script to show how to run a hyperparameter search on a cluster managed by SLURM
-
-Every distinct set of hyperparams runs on the configured hardware described in the SlurmCluster set up
-"""
-
-
-# main training function (very simple)
-def train(hparams):
-    # init exp and track all the parameters from the HyperOptArgumentParser
+    :param hparams: The arguments to run the model with.
+    """
+    # Initialize experiments and track all the hyperparameters
     exp = Experiment(
         name=hparams.test_tube_exp_name,
+        # Location to save the metrics.
         save_dir=hparams.log_path,
         autosave=False,
     )
     exp.argparse(hparams)
 
-    # pretend to train
+    # Pretend to train.
     x = torch.rand((1, hparams.x_val))
     for train_step in range(0, 100):
         y = torch.rand((hparams.x_val, 1))
         out = x.mm(y)
         exp.log({'fake_err': out.item()})
 
-    # save exp when we're done
+    # Save exp when .
     exp.save()
 
 
-# set up our argparser and make the y_val tunable
-parser = HyperOptArgumentParser(strategy='random_search')
-parser.add_argument('--test_tube_exp_name', default='my_test')
-parser.add_argument('--log_path', default='/some/path/to/log')
-parser.opt_list('--y_val', default=12, options=[1, 2, 3, 4, 5, 6], tunable=True)
-parser.opt_list('--x_val', default=12, options=[20, 12, 30, 45], tunable=True)
-hyperparams = parser.parse_args()
+if __name__ == '__main__':
+    # Set up our argparser and make the y_val tunable.
+    parser = HyperOptArgumentParser(strategy='random_search')
+    parser.add_argument('--test_tube_exp_name', default='my_test')
+    parser.add_argument('--log_path', default='/some/path/to/log')
+    parser.opt_list('--y_val',
+        default=12, options=[1, 2, 3, 4, 5, 6], tunable=True)
+    parser.opt_list('--x_val',
+        default=12, options=[20, 12, 30, 45], tunable=True)
+    hyperparams = parser.parse_args()
 
-# enable cluster training
-cluster = SlurmCluster(
-    hyperparam_optimizer=hyperparams,
-    log_path=hyperparams.log_path,
-    python_cmd='python3',
-    test_tube_exp_name=hyperparams.test_tube_exp_name
-)
+    # Enable cluster training.
+    cluster = SlurmCluster(
+        hyperparam_optimizer=hyperparams,
+        log_path=hyperparams.log_path,
+        python_cmd='python3',
+        test_tube_exp_name=hyperparams.test_tube_exp_name
+    )
 
-# email results if your hpc supports it
-cluster.notify_job_status(email='some@email.com', on_done=True, on_fail=True)
+    # Email results if your hpc supports it.
+    cluster.notify_job_status(
+        email='some@email.com', on_done=True, on_fail=True)
 
-# any modules for code to run in env
-cluster.load_modules([
-    'python-3',
-    'anaconda3'
-])
-cluster.add_command('source activate myCondaEnv')
+    # SLURM Module to load.
+    cluster.load_modules([
+        'python-3',
+        'anaconda3'
+    ])
 
-# set job compute details (this will apply PER set of hyperparameters)
-cluster.per_experiment_nb_gpus = 4
-cluster.per_experiment_nb_nodes = 2
-cluster.gpu_type = '1080ti'
+    # Add commands to the non-SLURM portion.
+    cluster.add_command('source activate myCondaEnv')
 
-# each job (24 in total here) will use 8 gpus for each set of hyperparams
-cluster.optimize_parallel_cluster_gpu(train, nb_trials=24, job_name='first_tt_job')
+    # Add custom SLURM commands which show up as:
+    # #comment
+    # #SBATCH --cmd=value
+    # ############
+    # cluster.add_slurm_cmd(
+    #    cmd='cpus-per-task', value='1', comment='CPUS per task.')
+
+    # Set job compute details (this will apply PER set of hyperparameters.)
+    cluster.per_experiment_nb_gpus = 4
+    cluster.per_experiment_nb_nodes = 2
+    cluster.gpu_type = '1080ti'
+
+    # Each hyperparameter combination will use 8 gpus.
+    cluster.optimize_parallel_cluster_gpu(
+        # Function to execute:
+        train,
+        # Number of hyperparameter combinations to search:
+        nb_trials=24,
+        # This is what will display in the slurm queue:
+        job_name='first_tt_job')


### PR DESCRIPTION
The SLURM example didn’t work for me right off the bad because the train function required 3 arguments and not 1 as shown in the example. This PR improves the overall usefulness of the examples. 