### PR TITLE
Fix for early slurm termination.

### DIFF
--- a/test_tube/hpc.py
+++ b/test_tube/hpc.py
@@ -247,10 +247,13 @@ class SlurmCluster(AbstractCluster):
             stop_in_n_seconds = max(stop_in_n_seconds, 10)  # make sure we don't go below the 5 mins
 
             # schedule timer to interrupt training
-            threading.Timer(stop_in_n_seconds, self.call_save).start()
+            timer_instance = threading.Timer(stop_in_n_seconds, self.call_save)
+            timer_instance.start()
 
             # run training
             train_function(self.hyperparam_optimizer, self, {})
+
+            timer_instance.cancel()
 
         except Exception as e:
             print('Caught exception in worker thread', e)


### PR DESCRIPTION
As discussed in the email, using test-tube on slurm might cause the job to run for the full time that it was requested for rather than terminating early when done. This can unnecessarily use quota.

Tested using the slurm installation on compute canada's Cedar. This code would execute much before the 1 hour mark. And therefore, the job should not take longer than 1 minute.

```
"""Example launcher for a hyperparameter search on SLURM."""
from test_tube import, HyperOptArgumentParser, SlurmCluster
import os
from mlresearchkit import io as mlio

def train(hparams, *args):
    """Train your awesome model.

    :param hparams: The arguments to run the model with.
    """
    # Initialize experiments and track all the hyperparameters
    mlio.touch('./HELLO WORLD THIS WORKS.txt')


if __name__ == '__main__':
    # Set up our argparser and make the y_val tunable.
    parser = HyperOptArgumentParser(strategy='random_search')
    parser.add_argument('--test_tube_exp_name', default='my_test')

    hyperparams = parser.parse_args()
    # Enable cluster training.
    cluster = SlurmCluster(
        hyperparam_optimizer=hyperparams,
        log_path='./',
        python_cmd='python3',
        test_tube_exp_name=hyperparams.test_tube_exp_name
    )

    cluster.add_slurm_cmd(
            cmd='account',
            value=COMPUTE_CANADA_ACCOUNT_HERE,
            comment='Account to run this on.'
            )

    # Add commands to the non-SLURM portion.
    cluster.add_command('source $ENV')

    # Set job compute details (this will apply PER set of hyperparameters.)
    cluster.per_experiment_nb_cpus = 1
    cluster.per_experiment_nb_nodes = 1
    cluster.job_time = '1:0:0'

    # Each hyperparameter combination will use 200 cpus.
    cluster.optimize_parallel_cluster_cpu(
        # Function to execute:
        train,
        # Number of hyperparameter combinations to search:
        nb_trials=1,
        job_name='first_tt_job',
        # This is what will display in the slurm queue:
        job_display_name='short_name')
```


I get:
`SLURM Job_id=14283562 Name=short_namev0 Ended, Run time 00:00:40, COMPLETED, ExitCode 0`


```
[zafarali@cedar5 examples]$ ls /scratch/zafarali/
'HELLO WORLD THIS WORKS.txt' 
```

