### PR TITLE
Fix bug in __get_hopt_params

### DIFF
--- a/test_tube/hpc.py
+++ b/test_tube/hpc.py
@@ -373,7 +373,7 @@ class SlurmCluster(AbstractCluster):
             v = trial.__dict__[k]
 
             # don't add None params
-            if v is None or v == False:
+            if v is None or v is False:
                 continue
 
             # put everything in quotes except bools


### PR DESCRIPTION
The problem is that if a trial param has a value of 0 (which could happen), it doesn't get added to the script params since `v == False` is `True` when `v=0`. Instead, `v is False` is only `True` when `v=False`, which I think is what was intended here.