### PR TITLE
cast np int64 to python int for json serialization

### DIFF
--- a/test_tube/argparse_hopt.py
+++ b/test_tube/argparse_hopt.py
@@ -507,7 +507,7 @@ class OptArg(object):
             if log_base is None:
                 # random search on uniform scale
                 if arg_type is int:
-                    self.opt_values = np.random.choice(np.arange(low, high), nb_samples, replace=False)
+                    self.opt_values = [int(_) for _ in np.random.choice(np.arange(low, high), nb_samples, replace=False)]
                 elif arg_type is float:
                     self.opt_values = np.random.uniform(low, high, nb_samples)
             else:


### PR DESCRIPTION
Fixes JSON serialization error, `TypeError: Object of type 'int64' is not JSON serializable`, due to creating random parameter choices using numpy