### PR TITLE
Make experiment version finding helper public

### DIFF
--- a/test_tube/log.py
+++ b/test_tube/log.py
@@ -248,13 +248,7 @@ class Experiment(SummaryWriter):
     def __get_last_experiment_version(self):
         try:
             exp_cache_file = os.sep.join(self.get_data_path(self.name, self.version).split(os.sep)[:-1])
-            last_version = -1
-            for f in os.listdir(exp_cache_file):
-                if 'version_' in f:
-                    file_parts = f.split('_')
-                    version = int(file_parts[-1])
-                    last_version = max(last_version, version)
-            return last_version
+            return find_last_experiment_version(exp_cache_file)
         except Exception as e:
             return -1
 
@@ -584,6 +578,15 @@ def atomic_write(dst_path):
         # If everything is fine, move tmp file to the destination.
         shutil.move(tmp_path, str(dst_path))
 
+
+def find_last_experiment_version(path):
+    last_version = -1
+    for f in os.listdir(path):
+        if 'version_' in f:
+            file_parts = f.split('_')
+            version = int(file_parts[-1])
+            last_version = max(last_version, version)
+    return last_version
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When resuming from a test-tube experiment I keep on finding myself reimplementing the ```__get_latest_experiment_version``` function. To address this - this PR separates the core functionality into a helper function and makes it a public staticmethod.

Now we can resume experiments easily with:

```
load_version = TestTubeLogger. find_last_experiment_version(ckpt_path) if args.resume else None
logger = TestTubeLogger(save_dir=args.exp_dir, version=load_version)
```